### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# The `CODEOWNERS` file defines who the code owners for specific or global files/directories in the repository are.
+
+# These owners will be the default reviewers for pull requests that touch these files/directories.
+
+# Default owners for every file in the repo.
+*       


### PR DESCRIPTION

This pull request was created by Oura’s Security Team and adds a `CODEOWNERS` file to this repository. The Codeowners are determined by selecting the top 5 committers to this repository.

The CODEOWNERS file is used to define individuals or teams that are responsible for code in a repository. This can then be used for automatic PR review assignment, contacting repo owners, and enabling further automation.

If you maintain this repo, it’s your baby and you decide who should be set as the owners - the 5 names we provided here are only a suggestion.

If this PR is not merged within 2 months, it will be automatically merged. More information can be found [in the slack announcement](https://ouraring.slack.com/archives/CUANE8SGP/p1718723100261059)
